### PR TITLE
Add setuptools-git-versioning 1.11.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,10 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c4c083cf7ab3fca54f73f096b7cb07aa7bdc479df0b4adaad8f1519c4a39b812
+  # No source distribution files available for v1.13.0 on pypi, 
+  # see https://pypi.org/project/setuptools-git-versioning/1.13.0/#files
+  url: https://github.com/dolfinus/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: f3d8940a10973d56210aeb57f2aceaa992555be87a3faa1fb78a4d20fe437a38
 
 build:
   number: 0
@@ -29,7 +31,7 @@ requirements:
     - packaging
     - python
     - setuptools
-    - toml >=0.10.2
+    - toml >=0.10.2  # [py<311]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,49 +1,57 @@
 {% set name = "setuptools-git-versioning" %}
-{% set version = "1.11.0" %}
+{% set version = "1.13.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/setuptools-git-versioning-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: c4c083cf7ab3fca54f73f096b7cb07aa7bdc479df0b4adaad8f1519c4a39b812
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
   number: 0
+  skip: True # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv
+  entry_points:
+    - setuptools-git-versioning=setuptools_git_versioning:__main__
 
 requirements:
   host:
     - deprecated
     - packaging
     - pip
-    - python >=3.7
+    - python
     - setuptools
-    - toml >=0.10.2
+    - toml
   run:
     - deprecated
     - packaging
-    - python >=3.7
+    - python
     - setuptools
     - toml >=0.10.2
 
 test:
   imports:
     - setuptools_git_versioning
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
+    - setuptools-git-versioning --help
 
 about:
   home: https://setuptools-git-versioning.readthedocs.io
   summary: Use git repo data for building a version number according PEP-440
+  description: |
+    Use git repo data (latest tag, current commit hash, etc) for building a version number according PEP 440.
   dev_url: https://github.com/dolfinus/setuptools-git-versioning
+  doc_url: https://setuptools-git-versioning.readthedocs.io/
+  doc_source_url: https://github.com/dolfinus/setuptools-git-versioning/tree/master/docs
   license: MIT
+  license_family: MIT
   license_file: LICENSE
-
+  license_url: https://github.com/dolfinus/setuptools-git-versioning/blob/v{{ version }}/LICENSE
 extra:
   recipe-maintainers:
     - BastianZim

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - python
     - setuptools
     - toml
+    - wheel
   run:
     - deprecated
     - packaging
@@ -57,3 +58,5 @@ about:
 extra:
   recipe-maintainers:
     - BastianZim
+  skip-lints:
+    - uses_setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,13 @@
 {% set name = "setuptools-git-versioning" %}
-{% set version = "1.13.0" %}
+{% set version = "1.11.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  # No source distribution files available for v1.13.0 on pypi, 
-  # see https://pypi.org/project/setuptools-git-versioning/1.13.0/#files
-  url: https://github.com/dolfinus/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: f3d8940a10973d56210aeb57f2aceaa992555be87a3faa1fb78a4d20fe437a38
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/setuptools-git-versioning-{{ version }}.tar.gz
+  sha256: c4c083cf7ab3fca54f73f096b7cb07aa7bdc479df0b4adaad8f1519c4a39b812
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,6 +55,7 @@ about:
   license_family: MIT
   license_file: LICENSE
   license_url: https://github.com/dolfinus/setuptools-git-versioning/blob/v{{ version }}/LICENSE
+
 extra:
   recipe-maintainers:
     - BastianZim

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True # [py<37]
+  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
     - setuptools-git-versioning=setuptools_git_versioning:__main__


### PR DESCRIPTION
It's a dependency of bokeh >=3.0.0, see https://github.com/AnacondaRecipes/bokeh-feedstock/pull/10/files

**The upstream data:**
Github releases:  https://github.com/dolfinus/setuptools-git-versioning/releases
License: https://github.com/dolfinus/setuptools-git-versioning/blob/master/LICENSE
Changelog: https://github.com/dolfinus/setuptools-git-versioning/blob/master/CHANGELOG.rst
Requirements:
- https://github.com/dolfinus/setuptools-git-versioning/blob/v1.11.0/requirements.txt
- https://github.com/dolfinus/setuptools-git-versioning/blob/v1.11.0/setup.py

**_Actions:_**

1. Remove `noarch python`
2. Skip `py<37`
3. Add `entry_points`
4. Remove pinnings for `python` in `host` and `run`, and for `toml` in `host`.
5. Add wheel to host
6. Add constraint `py<311` for `toml` because it was added to the standard library in **v3.11**.
7. Add the test command `setuptools-git-versioning --help`
8. Add a `description`
9. Add `doc_url` & `doc_source_url`
10. Add `license_family` & `license_url`
11. Add `skip-lints` for `uses_setuptools`

**_Notes:_**
 * Source file for versions >=1.12.0 are **not** available on `pypi`, see https://pypi.org/project/setuptools-git-versioning/1.12.0/#files
 * Versions `>=1.12.0` aren't building correctly: the version resets to `0.0.1`. 

**Package's statistics**
<details>

 * Priority  | effort:  | Category:  | subcategory:  | pkg_type: 
 * Outdated platfroms: 
 * Latest version: 

* [PyPi history](https://pypi.org/project/setuptools-git-versioning/#history)
 * Popularity: 
    * 3 months downloads: 
    * All time:  1454 downloads -  setuptools-git-versioning  1.11.0  Use git repo data for building a version number according PEP-440  copy  

</details>

**Links:**
<details>

* [dev_url](https://github.com/dolfinus/setuptools-git-versioning)
* [Bug tracker](https://github.com/dolfinus/setuptools-git-versioning/issues)
* [PyPi](https://pypi.org/project/setuptools-git-versioning)
* [conda-forge recipe](https://github.com/conda-forge/setuptools-git-versioning-feedstock/blob/master/recipe/meta.yaml)
* [Anaconda recipe feedstock](https://github.com/AnacondaRecipes/setuptools-git-versioning-feedstock)
* [Update branch: _v1.11.0_](https://github.com/AnacondaRecipes/setuptools-git-versioning-feedstock/tree/v1.11.0)
* [Diff between upstream conda-forge **main** and aggregate **feature** branch](https://github.com/conda-forge/setuptools-git-versioning-feedstock/compare/main...AnacondaRecipes:v1.11.0#files_bucket)
* [Diff between origin aggregate **master** and aggregate **feature** branch](https://github.com/AnacondaRecipes/setuptools-git-versioning-feedstock/compare/master...AnacondaRecipes:v1.11.0#files_bucket)
* [The last merged PRs](https://github.com/AnacondaRecipes/setuptools-git-versioning-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

</details>

**Anaconda Linter:**

<details>

All checks OK

</details>

**Other checks:**

<details>

1. - [x] The upstream url error:
    https://github.com/dolfinus/setuptools-git-versioning/tree/v1.11.0
12. - [x] Check the pinnings
13. - [x] https://github.com/dolfinus/setuptools-git-versioning/blob/master/CHANGELOG.rst exists
14. - [x] Additional research
    https://github.com/dolfinus/setuptools-git-versioning/issues
    200
15. - [x] `dev_url` is present
    https://github.com/dolfinus/setuptools-git-versioning
16. - [ ] `doc_url` error:
    https://setuptools-git-versioning.readthedocs.io/
    302
7. - [x] `doc_source_url` is present
    https://github.com/dolfinus/setuptools-git-versioning/tree/master/docs
17. - [x] Verify that the `build_number` is correct
18. - [x] Verify if the package needs `setuptools`
19. - [x] has `wheel`
20. - [x] `pip` in test
21. - [x] Verify the test section
22. - [x] Verify if the package is `architecture specific`
23. - [x] Verify that private module are not mentioned on the recipe For example: (_private_module)
24.  - [x] license_file: LICENSE is present
25. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier         |
|:-------------------|
| MIT                |
| MIT-0              |
| MIT-advertising    |
| MIT-CMU            |
| MIT-enna           |
| MIT-feh            |
| MIT-Modern-Variant |
| MIT-open-group     |
| MITNFA             |

26. - [x] license_family MIT is present
</details>


**Updating the recipe:**

If the recipe needs additional modification the update branch can be modified.

```
git clone -b v1.11.0 git@github.com:AnacondaRecipes/setuptools-git-versioning-feedstock.git
```

