### PR TITLE
1.13.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "setuptools-git-versioning" %}
-{% set version = "1.11.0" %}
+{% set version = "1.13.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/setuptools-git-versioning-{{ version }}.tar.gz
-  sha256: c4c083cf7ab3fca54f73f096b7cb07aa7bdc479df0b4adaad8f1519c4a39b812
+  sha256: fde1a7cb3b2566979e5651cfca0d33cd5a82771711cd38a056216391936cf0ff
 
 build:
   number: 0
@@ -18,15 +18,13 @@ build:
 
 requirements:
   host:
-    - deprecated
     - packaging
     - pip
     - python
     - setuptools
-    - toml
+    - toml >=0.10.2  # [py<311]
     - wheel
   run:
-    - deprecated
     - packaging
     - python
     - setuptools


### PR DESCRIPTION
Changes:
- Update to 1.13.1

Reason: needed for python 3.11 compatiblity

https://github.com/dolfinus/setuptools-git-versioning

https://anaconda.atlassian.net/browse/PKG-870